### PR TITLE
Updated to refer to the latest SNAPSHOT

### DIFF
--- a/src/MicroFocus.FAS.Adapters.Rest/MicroFocus.FAS.Adapters.Rest.csproj
+++ b/src/MicroFocus.FAS.Adapters.Rest/MicroFocus.FAS.Adapters.Rest.csproj
@@ -26,8 +26,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroFocus.FAS.AdapterSdk.Api" Version="1.0.0-SNAPSHOT" />
-    <PackageReference Include="MicroFocus.FAS.Adapters.Rest.Client" Version="1.0.0-SNAPSHOT" />
+    <PackageReference Include="MicroFocus.FAS.AdapterSdk.Api" Version="1.0.0-SNAPSHOT-*" />
+    <PackageReference Include="MicroFocus.FAS.Adapters.Rest.Client" Version="1.0.0-SNAPSHOT-*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Following the changes made for [sepg/issue-tracking#61](https://github.houston.softwaregrp.net/sepg/issue-tracking/issues/61) and [sepg/issue-tracking#62](https://github.houston.softwaregrp.net/sepg/issue-tracking/issues/62) we should now be able to update the package references to use a [floating version](https://docs.microsoft.com/en-us/nuget/concepts/dependency-resolution#floating-versions), so that it always uses the latest SNAPSHOT.